### PR TITLE
Simplify Cypress Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ yarn-error.log
 # Test outputs we shouldn't commit
 cypress/videos
 cypress/screenshots
+
+# Environment configuration we shouldn't commit
+/cypress.env.json

--- a/circle.yml
+++ b/circle.yml
@@ -35,7 +35,7 @@ jobs:
           <<: *restore-cache
       - run:
           name: Code Lint
-          command: yarn lint
+          command: yarn ci:lint
   build:
     <<: *defaults
     steps:
@@ -44,7 +44,7 @@ jobs:
           <<: *restore-cache
       - run:
           name: Build Application
-          command: yarn build
+          command: yarn ci:build
       - persist_to_workspace:
           root: .
           paths: public
@@ -56,7 +56,7 @@ jobs:
           <<: *restore-cache
       - run:
           name: Unit Tests
-          command: yarn test
+          command: yarn ci:unit-tests
   feature-tests:
     <<: *defaults
     docker:
@@ -69,11 +69,11 @@ jobs:
           <<: *restore-cache
       - run:
           name: Start application server
-          command: yarn serve
+          command: yarn ci:start-server
           background: true
       - run:
           name: Feature Tests
-          command: yarn test:features
+          command: yarn ci:feature-tests
 workflows:
   version: 2
   build-and-test:

--- a/cypress.env.json.example
+++ b/cypress.env.json.example
@@ -1,0 +1,7 @@
+# you can use this file to override baseUrl from cypress.json and also
+# to provide environment variables to our integration test suite via
+# Cypress.env('KEY')
+
+{
+  "baseUrl": "http://yld.netlify.com/"
+}

--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
+  "baseUrl": "http://localhost:8000/",
   "pluginsFile": false
 }

--- a/cypress/integration/homepage.js
+++ b/cypress/integration/homepage.js
@@ -1,15 +1,12 @@
-import { baseUrl } from '../support/config';
-
 describe('features/homepage', () => {
   it('visits the homepage', () => {
-    cy.visit(baseUrl);
+    cy.visit('/');
 
     cy.title().should('eq', 'Gatsby Default Starter');
   });
 
   it('allows navigation to page 2', () => {
-    cy.visit(baseUrl);
-
+    cy.visit('/');
     cy.contains('Go to page 2').click();
 
     cy.contains('Hi from the second page').should('be.visible');

--- a/cypress/support/config.js
+++ b/cypress/support/config.js
@@ -1,2 +1,0 @@
-export const baseUrl = process.env.APP_URL || 'http://localhost:9000/';
-export const blog = '/blog';

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
+    "ci:build": "yarn build",
+    "ci:lint": "yarn lint",
+    "ci:start-server": "yarn serve -p 8000",
+    "ci:unit-tests": "yarn test",
+    "ci:feature-tests": "yarn test:features",
     "develop": "gatsby develop",
     "format": "prettier --write 'src/**/*.{js,jsx}'",
     "serve": "gatsby serve",


### PR DESCRIPTION
Running `yarn cypress` with the development server active does not work, as it is on port 8000 (cypress currently expects 9000). I've remedied this by setting the url it expects to be on port 8000 and in the process simplified the configuration a bit.

- Used cypress' `baseUrl` feature instead of our own config.
- Provided `cypress.env.json.example` which allows people to override it locally if they wish
- Moved CI tasks into their own namespaced scripts in `package.json` so we have a clear distinction.