### PR TITLE
babel-plugin-styled-components: enable displayName in test

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,26 +1,15 @@
 {
   "env": {
     "test": {
-      "presets": [["env"], "react"]
+      "presets": [["env"], "react"],
+      "plugins": [["babel-plugin-styled-components", { "displayName": true }]]
     },
     "production": {
-      "plugins": [
-        [
-          "babel-plugin-styled-components",
-          {
-            "displayName": false
-          }
-        ]
-      ]
+      "plugins": [["babel-plugin-styled-components", { "displayName": false }]]
     }
   },
   "plugins": [
-    [
-      "module-resolver",
-      {
-        "root": ["./src"]
-      }
-    ],
-    "babel-plugin-styled-components"
+    ["module-resolver", { "root": ["./src"] }],
+    ["babel-plugin-styled-components", { "displayName": true }]
   ]
 }

--- a/src/components/Button/__snapshots__/spec.jsx.snap
+++ b/src/components/Button/__snapshots__/spec.jsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/Button anchor snapshot 1`] = `<styled.a />`;
+exports[`components/Button anchor snapshot 1`] = `<styled />`;
 
-exports[`components/Button basic snapshot 1`] = `<styled.a />`;
+exports[`components/Button basic snapshot 1`] = `<styled />`;
 
-exports[`components/Button button snapshot 1`] = `<styled.button />`;
+exports[`components/Button button snapshot 1`] = `<styled />`;
 
-exports[`components/Button custom component snapshot 1`] = `<Styled(mockComponent) />`;
+exports[`components/Button custom component snapshot 1`] = `<styled />`;

--- a/src/components/CheckList/__snapshots__/spec.jsx.snap
+++ b/src/components/CheckList/__snapshots__/spec.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/CheckList snapshot 1`] = `
-<styled.ul>
+<styled__List>
   <Item>
     Hello, world
   </Item>
@@ -11,5 +11,5 @@ exports[`components/CheckList snapshot 1`] = `
   <Item>
     And a third
   </Item>
-</styled.ul>
+</styled__List>
 `;

--- a/src/components/Footer/FooterClosing/__snapshots__/spec.jsx.snap
+++ b/src/components/Footer/FooterClosing/__snapshots__/spec.jsx.snap
@@ -1,36 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/FooterClosing snapshot 1`] = `
-<styled.section>
-  <styled.p>
+<styled__Container>
+  <styled__Copyright>
     © 2018 Made with love by YLD. All rights reserved
-  </styled.p>
-  <styled.ul>
-    <styled.li>
-      <Styled(Link)
+  </styled__Copyright>
+  <styled__Copyright>
+    <styled__SiteLink>
+      <styled__Link
         href="/privacy-policy"
       >
         Privacy
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__SiteLink>
+    <styled__SiteLink>
+      <styled__Link
         href="/terms"
       >
         Terms
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__SiteLink>
+    <styled__SiteLink>
+      <styled__Link
         href="/sitemap"
       >
         Sitemap
-      </Styled(Link)>
-    </styled.li>
-  </styled.ul>
-  <styled.ul>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__SiteLink>
+  </styled__Copyright>
+  <styled__SocialLinks>
+    <styled__SiteLink>
+      <styled__Link
         href="https://twitter.com/yldio"
       >
         <FontAwesomeIcon
@@ -62,10 +62,10 @@ exports[`components/FooterClosing snapshot 1`] = `
           symbol={false}
           transform={null}
         />
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__SiteLink>
+    <styled__SiteLink>
+      <styled__Link
         href="https://github.com/yldio"
       >
         <FontAwesomeIcon
@@ -97,10 +97,10 @@ exports[`components/FooterClosing snapshot 1`] = `
           symbol={false}
           transform={null}
         />
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__SiteLink>
+    <styled__SiteLink>
+      <styled__Link
         href="https://youtube.com"
       >
         <FontAwesomeIcon
@@ -132,8 +132,8 @@ exports[`components/FooterClosing snapshot 1`] = `
           symbol={false}
           transform={null}
         />
-      </Styled(Link)>
-    </styled.li>
-  </styled.ul>
-</styled.section>
+      </styled__Link>
+    </styled__SiteLink>
+  </styled__SocialLinks>
+</styled__Container>
 `;

--- a/src/components/Footer/FooterContactList/__snapshots__/spec.jsx.snap
+++ b/src/components/Footer/FooterContactList/__snapshots__/spec.jsx.snap
@@ -1,65 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/FooterContactList snapshot 1`] = `
-<styled.ul>
-  <styled.li>
+<styled__List>
+  <styled__Contact>
     <address>
-      <styled.h6>
+      <styled__Line>
         London
-      </styled.h6>
-      <styled.p>
+      </styled__Line>
+      <styled__Line>
         124 Aldersgate Street
-      </styled.p>
-      <styled.p>
+      </styled__Line>
+      <styled__Line>
         EC1A 4JQ
-      </styled.p>
-      <styled.p>
-        <Styled(Link)
+      </styled__Line>
+      <styled__Line>
+        <styled__Link
           href="tel:+44-203-514-4678"
         >
           +44 (0) 203 514 4678
-        </Styled(Link)>
-      </styled.p>
-      <styled.p>
-        <Styled(Link)
+        </styled__Link>
+      </styled__Line>
+      <styled__Line>
+        <styled__Link
           href="mailto:hello@yld.io"
         >
           hello@yld.io
-        </Styled(Link)>
-      </styled.p>
+        </styled__Link>
+      </styled__Line>
     </address>
-  </styled.li>
-  <styled.li>
+  </styled__Contact>
+  <styled__Contact>
     <address>
-      <styled.h6>
+      <styled__Line>
         Lisbon
-      </styled.h6>
-      <styled.p>
+      </styled__Line>
+      <styled__Line>
         Rua Ramalho Ortigão 8
-      </styled.p>
-      <styled.p>
+      </styled__Line>
+      <styled__Line>
         3rd floor left
-      </styled.p>
-      <styled.p>
+      </styled__Line>
+      <styled__Line>
         1070-230
-      </styled.p>
+      </styled__Line>
     </address>
-  </styled.li>
-  <styled.li>
+  </styled__Contact>
+  <styled__Contact>
     <address>
-      <styled.h6>
+      <styled__Line>
         Porto
-      </styled.h6>
-      <styled.p>
+      </styled__Line>
+      <styled__Line>
         Rua Ramalho Ortigão 8
-      </styled.p>
-      <styled.p>
+      </styled__Line>
+      <styled__Line>
         3rd floor left
-      </styled.p>
-      <styled.p>
+      </styled__Line>
+      <styled__Line>
         1070-230
-      </styled.p>
+      </styled__Line>
     </address>
-  </styled.li>
-</styled.ul>
+  </styled__Contact>
+</styled__List>
 `;

--- a/src/components/Footer/FooterNavigation/__snapshots__/spec.jsx.snap
+++ b/src/components/Footer/FooterNavigation/__snapshots__/spec.jsx.snap
@@ -1,104 +1,104 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/FooterNavigation snapshot 1`] = `
-<styled.nav>
-  <styled.ul>
-    <styled.li
+<styled__Nav>
+  <styled__Category>
+    <styled__Item
       header={true}
     >
       What we do
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="/services"
       >
         Services
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="/our-approach"
       >
         Our Approach
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="#how-we-do-it"
       >
         How we do it
-      </Styled(Link)>
-    </styled.li>
-  </styled.ul>
-  <styled.ul>
-    <styled.li
+      </styled__Link>
+    </styled__Item>
+  </styled__Category>
+  <styled__Category>
+    <styled__Item
       header={true}
     >
       Our work
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="/case-studies"
       >
         Case Studies
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="/industries"
       >
         Industries
-      </Styled(Link)>
-    </styled.li>
-  </styled.ul>
-  <styled.ul>
-    <styled.li
+      </styled__Link>
+    </styled__Item>
+  </styled__Category>
+  <styled__Category>
+    <styled__Item
       header={true}
     >
       Who we are
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="/about-us"
       >
         About Us
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="/join-us"
       >
         Join Us
-      </Styled(Link)>
-    </styled.li>
-  </styled.ul>
-  <styled.ul>
-    <styled.li
+      </styled__Link>
+    </styled__Item>
+  </styled__Category>
+  <styled__Category>
+    <styled__Item
       header={true}
     >
       Our Community
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="/talks"
       >
         Talks
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="/events"
       >
         Events
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="/blog"
       >
         Blog
-      </Styled(Link)>
-    </styled.li>
-  </styled.ul>
-</styled.nav>
+      </styled__Link>
+    </styled__Item>
+  </styled__Category>
+</styled__Nav>
 `;

--- a/src/components/Header/__snapshots__/spec.jsx.snap
+++ b/src/components/Header/__snapshots__/spec.jsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/Header snapshot 1`] = `
-<styled.header>
+<styled__Wrapper>
   <Logo />
   <Navigation />
-</styled.header>
+</styled__Wrapper>
 `;

--- a/src/components/Link/__snapshots__/spec.jsx.snap
+++ b/src/components/Link/__snapshots__/spec.jsx.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/Link external link snapshot 1`] = `
-<styled.a
+<styled__StyledLink
   href="https://test.com/"
 >
   Test
-</styled.a>
+</styled__StyledLink>
 `;
 
 exports[`components/Link internal link snapshot 1`] = `
-<Styled(GatsbyLink)
+<styled__StyledLink
   activeClassName="___active"
   to="/test"
 >
   Test
-</Styled(GatsbyLink)>
+</styled__StyledLink>
 `;

--- a/src/components/Link/index.jsx
+++ b/src/components/Link/index.jsx
@@ -1,12 +1,9 @@
-import GatsbyLink from 'gatsby-link';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { StyledLink } from './styled';
+import { InternalLink, StyledLink } from './styled';
 
 const internalRegExp = /^\/(?!\/)/;
 export const isInternal = href => internalRegExp.test(href);
-
-const InternalLink = StyledLink.withComponent(GatsbyLink);
 
 export const activeClassName = '___active';
 

--- a/src/components/Link/spec.jsx
+++ b/src/components/Link/spec.jsx
@@ -18,13 +18,13 @@ describe('components/Link', () => {
   test('uses GatsbyLink for internal links', () => {
     const wrapper = shallow(<Link href="/internal">Internal</Link>);
 
-    expect(wrapper.is('Styled(GatsbyLink)')).toBe(true);
+    expect(wrapper.prop('to')).toEqual('/internal');
   });
 
   test('uses anchor for external links', () => {
     const wrapper = shallow(<Link href="https://external.com/">External</Link>);
 
-    expect(wrapper.text()).toContain('styled.a');
+    expect(wrapper.is('styled__StyledLink')).toBe(true);
   });
 
   test('isInternal', () => {

--- a/src/components/Link/styled.js
+++ b/src/components/Link/styled.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { highlight } from 'styles/colours';
+import GatsbyLink from 'gatsby-link';
 
 export const StyledLink = styled.a`
   color: ${highlight};
@@ -10,3 +11,5 @@ export const StyledLink = styled.a`
     text-decoration: underline;
   }
 `;
+
+export const InternalLink = StyledLink.withComponent(GatsbyLink);

--- a/src/components/Logo/__snapshots__/spec.jsx.snap
+++ b/src/components/Logo/__snapshots__/spec.jsx.snap
@@ -4,7 +4,7 @@ exports[`components/Logo snapshot 1`] = `
 <GatsbyLink
   to="/"
 >
-  <styled.img
+  <styled__LogoImage
     alt="YLD Logo"
     src="/src/components/Logo/logo.svg"
   />

--- a/src/components/Navigation/__snapshots__/spec.jsx.snap
+++ b/src/components/Navigation/__snapshots__/spec.jsx.snap
@@ -2,43 +2,43 @@
 
 exports[`components/Navigation snapshot 1`] = `
 <nav>
-  <styled.ul>
-    <styled.li>
-      <Styled(Link)
+  <styled__List>
+    <styled__Item>
+      <styled__Link
         href="/case-studies"
       >
         Case Studies
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="/services"
       >
         Services
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="/community"
       >
         Community
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="/about-us"
         padRight={true}
       >
         About Us
-      </Styled(Link)>
-    </styled.li>
-    <styled.li>
-      <Styled(Link)
+      </styled__Link>
+    </styled__Item>
+    <styled__Item>
+      <styled__Link
         href="/join-us"
       >
         Join Us
-      </Styled(Link)>
-    </styled.li>
-  </styled.ul>
+      </styled__Link>
+    </styled__Item>
+  </styled__List>
 </nav>
 `;

--- a/src/components/PageRule/__snapshots__/spec.jsx.snap
+++ b/src/components/PageRule/__snapshots__/spec.jsx.snap
@@ -5,7 +5,7 @@ exports[`components/PageRule snapshot 1`] = `
   margin: 100px 0;
 }
 
-<styled.hr
+<Rule
   className="c0"
 />
 `;

--- a/src/components/PageSectionHeader/__snapshots__/spec.jsx.snap
+++ b/src/components/PageSectionHeader/__snapshots__/spec.jsx.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/PageSection snapshot 1`] = `
-<styled.header>
-  <styled.h2>
+<styled__Container>
+  <styled__Title>
     Hello, world!
-  </styled.h2>
-</styled.header>
+  </styled__Title>
+</styled__Container>
 `;
 
 exports[`components/PageSection snapshot with description 1`] = `
-<styled.header>
-  <styled.h2>
+<styled__Container>
+  <styled__Title>
     Hello, world!
-  </styled.h2>
-  <styled.p>
+  </styled__Title>
+  <styled__Description>
     This is some support copy
-  </styled.p>
-</styled.header>
+  </styled__Description>
+</styled__Container>
 `;

--- a/src/components/Post/__snapshots__/spec.jsx.snap
+++ b/src/components/Post/__snapshots__/spec.jsx.snap
@@ -1,73 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/Post snapshot 1`] = `
-<styled.article
+<Panel
   stretch={true}
 >
-  <styled.header>
-    <styled.h4>
+  <styled__Header>
+    <styled__Title>
       We’re Hiring! YLD on the look out for Front-End Devs and DevOps.
-    </styled.h4>
-  </styled.header>
-  <styled.main>
+    </styled__Title>
+  </styled__Header>
+  <styled__Body>
     I think its one of the simplest yet most powerful extensions inVision
     hasn't launched. As animation and transition in inVision evolve it
     should grow even more powerful
-  </styled.main>
-  <Styled(styled.hr) />
-  <styled.footer>
-    <styled.img
+  </styled__Body>
+  <styled__PostRule />
+  <styled__Footer>
+    <styled__Thumbnail
       src="https://placekitten.com/128/128"
     />
-    <styled.p>
+    <styled__Authored>
       <Link
         activeClassName="___active"
         href="/people/nuno-job"
       >
         Nuno Job
       </Link>
-      <styled.time
+      <styled__Time
         datetime="2018-05-18T14:38:23.996+01:00"
       >
         May 18
-      </styled.time>
-    </styled.p>
-  </styled.footer>
-</styled.article>
+      </styled__Time>
+    </styled__Authored>
+  </styled__Footer>
+</Panel>
 `;
 
 exports[`components/Post snapshot with stretch=false 1`] = `
-<styled.article
+<Panel
   stretch={false}
 >
-  <styled.header>
-    <styled.h4>
+  <styled__Header>
+    <styled__Title>
       We’re Hiring! YLD on the look out for Front-End Devs and DevOps.
-    </styled.h4>
-  </styled.header>
-  <styled.main>
+    </styled__Title>
+  </styled__Header>
+  <styled__Body>
     I think its one of the simplest yet most powerful extensions inVision
     hasn't launched. As animation and transition in inVision evolve it
     should grow even more powerful
-  </styled.main>
-  <Styled(styled.hr) />
-  <styled.footer>
-    <styled.img
+  </styled__Body>
+  <styled__PostRule />
+  <styled__Footer>
+    <styled__Thumbnail
       src="https://placekitten.com/128/128"
     />
-    <styled.p>
+    <styled__Authored>
       <Link
         activeClassName="___active"
         href="/people/nuno-job"
       >
         Nuno Job
       </Link>
-      <styled.time
+      <styled__Time
         datetime="2018-05-18T14:38:23.996+01:00"
       >
         May 18
-      </styled.time>
-    </styled.p>
-  </styled.footer>
-</styled.article>
+      </styled__Time>
+    </styled__Authored>
+  </styled__Footer>
+</Panel>
 `;

--- a/src/components/TileGrid/__snapshots__/spec.jsx.snap
+++ b/src/components/TileGrid/__snapshots__/spec.jsx.snap
@@ -16,20 +16,20 @@ exports[`components/TileGrid snapshot with tiles 1`] = `
 <ul
   className="c0"
 >
-  <styled.li
+  <styled__Tile
     colour="normal"
   >
     Hello
-  </styled.li>
-  <styled.li
+  </styled__Tile>
+  <styled__Tile
     colour="dark"
   >
     World
-  </styled.li>
-  <styled.li
+  </styled__Tile>
+  <styled__Tile
     colour="darker"
   >
     !
-  </styled.li>
+  </styled__Tile>
 </ul>
 `;

--- a/src/compositions/pages/Home/BuildBetter/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/BuildBetter/__snapshots__/spec.jsx.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`compositions/homepage/BuildBetter snapshot 1`] = `
-<styled.section>
-  <styled.h2>
+<Container>
+  <styled__Title>
     Build better
-  </styled.h2>
-  <styled.p>
+  </styled__Title>
+  <styled__Body>
     Great companies go beyond their customers expectations, over and over again. Building this capability in your company is our mission, and our promise.
-  </styled.p>
-  <styled.p>
+  </styled__Body>
+  <styled__Body>
     We enable your organisation to deliver world-class technology and customer experiences.
-  </styled.p>
+  </styled__Body>
   <Button
     component="a"
     href="#case-studies"
   >
     Case Studies ↓
   </Button>
-</styled.section>
+</Container>
 `;

--- a/src/compositions/pages/Home/CaseStudies/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/CaseStudies/__snapshots__/spec.jsx.snap
@@ -1,62 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`compositions/homepage/CaseStudies snapshot 1`] = `
-<styled.section
+<Container
   wide={true}
 >
-  <styled.ul>
-    <styled.li>
-      <styled.div>
-        <styled.h5>
+  <TileGrid>
+    <styled__Tile>
+      <styled__TileContent>
+        <styled__TileContentTitle>
           Trainline
-        </styled.h5>
-        <styled.p>
+        </styled__TileContentTitle>
+        <styled__TileContentBody>
           A legacy platform that faced a huge pressure to have an updated interface.
-        </styled.p>
-      </styled.div>
-    </styled.li>
-    <styled.li
+        </styled__TileContentBody>
+      </styled__TileContent>
+    </styled__Tile>
+    <styled__Tile
       colour="darker"
     >
-      <styled.div>
-        <styled.h5>
+      <styled__TileContent>
+        <styled__TileContentTitle>
           The Economist
-        </styled.h5>
-        <styled.p>
+        </styled__TileContentTitle>
+        <styled__TileContentBody>
           A legacy platform that faced a huge pressure to have an updated interface.
-        </styled.p>
-      </styled.div>
-    </styled.li>
-    <styled.li
+        </styled__TileContentBody>
+      </styled__TileContent>
+    </styled__Tile>
+    <styled__Tile
       colour="dark"
     >
-      <styled.div>
-        <styled.h5>
+      <styled__TileContent>
+        <styled__TileContentTitle>
           Joyent
-        </styled.h5>
-        <styled.p>
+        </styled__TileContentTitle>
+        <styled__TileContentBody>
           A legacy platform that faced a huge pressure to have an updated interface.
-        </styled.p>
-      </styled.div>
-    </styled.li>
-    <styled.li>
-      <styled.div>
-        <styled.h5>
+        </styled__TileContentBody>
+      </styled__TileContent>
+    </styled__Tile>
+    <styled__Tile>
+      <styled__TileContent>
+        <styled__TileContentTitle>
           Doctor Link
-        </styled.h5>
-        <styled.p>
+        </styled__TileContentTitle>
+        <styled__TileContentBody>
           A legacy platform that faced a huge pressure to have an updated interface.
-        </styled.p>
-      </styled.div>
-    </styled.li>
-  </styled.ul>
-  <styled.p>
+        </styled__TileContentBody>
+      </styled__TileContent>
+    </styled__Tile>
+  </TileGrid>
+  <styled__CallToAction>
     <Button
       component={[Function]}
       href="/case-studies"
     >
       View More
     </Button>
-  </styled.p>
-</styled.section>
+  </styled__CallToAction>
+</Container>
 `;

--- a/src/compositions/pages/Home/Community/RecentBlogPosts/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/Community/RecentBlogPosts/__snapshots__/spec.jsx.snap
@@ -3,12 +3,12 @@
 exports[`compositions/Home/Community/RecentBlogPosts snapshot 1`] = `
 <section>
   <header>
-    <styled.h3>
+    <styled__Title>
       Recent Blog Posts
-    </styled.h3>
+    </styled__Title>
   </header>
-  <styled.ul>
-    <styled.li>
+  <styled__BlogPosts>
+    <styled__BlogPost>
       <Post
         date="2018-05-18T14:38:23.996+01:00"
         image="https://placekitten.com/128/128"
@@ -19,8 +19,8 @@ exports[`compositions/Home/Community/RecentBlogPosts snapshot 1`] = `
       >
         I think its one of the simplest yet most powerful extensions inVision hasn't launched. As animation and transition in inVision evolve it should grow even more powerful
       </Post>
-    </styled.li>
-    <styled.li>
+    </styled__BlogPost>
+    <styled__BlogPost>
       <Post
         date="2018-05-18T14:38:23.996+01:00"
         image="https://placekitten.com/128/128"
@@ -31,8 +31,8 @@ exports[`compositions/Home/Community/RecentBlogPosts snapshot 1`] = `
       >
         I think its one of the simplest yet most powerful extensions inVision hasn't launched. As animation and transition in inVision evolve it should grow even more powerful
       </Post>
-    </styled.li>
-  </styled.ul>
+    </styled__BlogPost>
+  </styled__BlogPosts>
   <Button
     component={[Function]}
     href="/blog"

--- a/src/compositions/pages/Home/Community/UpcomingEvents/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/Community/UpcomingEvents/__snapshots__/spec.jsx.snap
@@ -3,12 +3,12 @@
 exports[`compositions/Home/Community/UpcomingEvents snapshot 1`] = `
 <section>
   <header>
-    <styled.h3>
+    <styled__Title>
       Upcoming Events
-    </styled.h3>
+    </styled__Title>
   </header>
-  <styled.ul>
-    <styled.li>
+  <styled__Events>
+    <styled__Event>
       <Post
         date="2018-05-18T14:38:23.996+01:00"
         image="https://placekitten.com/128/128"
@@ -19,8 +19,8 @@ exports[`compositions/Home/Community/UpcomingEvents snapshot 1`] = `
       >
         I think its one of the simplest yet most powerful extensions inVision hasn't launched.
       </Post>
-    </styled.li>
-    <styled.li>
+    </styled__Event>
+    <styled__Event>
       <Post
         date="2018-05-18T14:38:23.996+01:00"
         image="https://placekitten.com/128/128"
@@ -31,8 +31,8 @@ exports[`compositions/Home/Community/UpcomingEvents snapshot 1`] = `
       >
         I think its one of the simplest yet most powerful extensions inVision hasn't launched.
       </Post>
-    </styled.li>
-    <styled.li>
+    </styled__Event>
+    <styled__Event>
       <Post
         date="2018-05-18T14:38:23.996+01:00"
         image="https://placekitten.com/128/128"
@@ -43,8 +43,8 @@ exports[`compositions/Home/Community/UpcomingEvents snapshot 1`] = `
       >
         I think its one of the simplest yet most powerful extensions inVision hasn't launched.
       </Post>
-    </styled.li>
-  </styled.ul>
+    </styled__Event>
+  </styled__Events>
   <Button
     component={[Function]}
     href="/events"

--- a/src/compositions/pages/Home/Community/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/Community/__snapshots__/spec.jsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`compositions/Home/Community snapshot 1`] = `
-<styled.section>
+<Container>
   <PageSectionHeader
     description="We define ourselves by the people who represent us. Our emphasis on community and culture creates an environment where we prioritise supporting and nurturing people’s development."
     title="Community"
   />
   <RecentBlogPosts />
-  <Styled(Styled(styled.hr)) />
+  <styled__Rule />
   <UpcomingEvents />
-</styled.section>
+</Container>
 `;

--- a/src/compositions/pages/Home/HowWeDoIt/ProductList/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/HowWeDoIt/ProductList/__snapshots__/spec.jsx.snap
@@ -1,133 +1,133 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/ProductList snapshot 1`] = `
-<styled.ul>
-  <styled.li>
-    <styled.img
+<Panel>
+  <styled__ProductColumn>
+    <styled__Image
       alt="our approach"
       src="/src/compositions/pages/Home/HowWeDoIt/ProductList/placeholder.svg"
     />
-    <styled.header>
+    <styled__Title>
       Our Approach
-    </styled.header>
-    <styled.ul>
-      <styled.li>
+    </styled__Title>
+    <styled__ProductSublist>
+      <styled__Product>
         Digital Transformation
-      </styled.li>
-      <styled.li>
+      </styled__Product>
+      <styled__Product>
         Engineering Consultancy
-      </styled.li>
-      <styled.li>
+      </styled__Product>
+      <styled__Product>
         Product Consultancy
-      </styled.li>
-    </styled.ul>
-    <styled.footer>
+      </styled__Product>
+    </styled__ProductSublist>
+    <styled__Footer>
       <Link
         activeClassName="___active"
         href="/services#approach"
       >
         More on Approach →
       </Link>
-    </styled.footer>
-  </styled.li>
-  <styled.li>
-    <styled.img
+    </styled__Footer>
+  </styled__ProductColumn>
+  <styled__ProductColumn>
+    <styled__Image
       alt="design & product"
       src="/src/compositions/pages/Home/HowWeDoIt/ProductList/placeholder.svg"
     />
-    <styled.header>
+    <styled__Title>
       Design & Product
-    </styled.header>
-    <styled.ul>
-      <styled.li>
+    </styled__Title>
+    <styled__ProductSublist>
+      <styled__Product>
         Design Systems & Design Operations
-      </styled.li>
-      <styled.li>
+      </styled__Product>
+      <styled__Product>
         Design Sprints
-      </styled.li>
-      <styled.li>
+      </styled__Product>
+      <styled__Product>
         User Interface Design & Branding
-      </styled.li>
-      <styled.li>
+      </styled__Product>
+      <styled__Product>
         Research, Usability and User Experience
-      </styled.li>
-    </styled.ul>
-    <styled.footer>
+      </styled__Product>
+    </styled__ProductSublist>
+    <styled__Footer>
       <Link
         activeClassName="___active"
         href="/services#design"
       >
         More on Design →
       </Link>
-    </styled.footer>
-  </styled.li>
-  <styled.li>
-    <styled.img
+    </styled__Footer>
+  </styled__ProductColumn>
+  <styled__ProductColumn>
+    <styled__Image
       alt="engineering"
       src="/src/compositions/pages/Home/HowWeDoIt/ProductList/placeholder.svg"
     />
-    <styled.header>
+    <styled__Title>
       Engineering
-    </styled.header>
-    <styled.ul>
-      <styled.li>
+    </styled__Title>
+    <styled__ProductSublist>
+      <styled__Product>
         Engineering Leadership
-      </styled.li>
-      <styled.li>
+      </styled__Product>
+      <styled__Product>
         Back End & Node.js
-      </styled.li>
-      <styled.li>
+      </styled__Product>
+      <styled__Product>
         Front End & React.js
-      </styled.li>
-      <styled.li>
+      </styled__Product>
+      <styled__Product>
         DevOps & Kubernetes
-      </styled.li>
-      <styled.li>
+      </styled__Product>
+      <styled__Product>
         Mobile & React Native
-      </styled.li>
-    </styled.ul>
-    <styled.footer>
+      </styled__Product>
+    </styled__ProductSublist>
+    <styled__Footer>
       <Link
         activeClassName="___active"
         href="/services#engineering"
       >
         More on Engineering →
       </Link>
-    </styled.footer>
-  </styled.li>
-  <styled.li>
-    <styled.img
+    </styled__Footer>
+  </styled__ProductColumn>
+  <styled__ProductColumn>
+    <styled__Image
       alt="training"
       src="/src/compositions/pages/Home/HowWeDoIt/ProductList/placeholder.svg"
     />
-    <styled.header>
+    <styled__Title>
       Training
-    </styled.header>
-    <styled.ul>
-      <styled.li>
+    </styled__Title>
+    <styled__ProductSublist>
+      <styled__Product>
         Node Training
-      </styled.li>
-      <styled.li>
+      </styled__Product>
+      <styled__Product>
         React Training
-      </styled.li>
-      <styled.li>
+      </styled__Product>
+      <styled__Product>
         Design Systems Training
-      </styled.li>
-      <styled.li>
+      </styled__Product>
+      <styled__Product>
         UX Research Training
-      </styled.li>
-      <styled.li>
+      </styled__Product>
+      <styled__Product>
         UX Design Training
-      </styled.li>
-    </styled.ul>
-    <styled.footer>
+      </styled__Product>
+    </styled__ProductSublist>
+    <styled__Footer>
       <Link
         activeClassName="___active"
         href="/services#training"
       >
         More on Training →
       </Link>
-    </styled.footer>
-  </styled.li>
-</styled.ul>
+    </styled__Footer>
+  </styled__ProductColumn>
+</Panel>
 `;

--- a/src/compositions/pages/Home/HowWeDoIt/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/HowWeDoIt/__snapshots__/spec.jsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`compositions/homepage/HowWeDoIt snapshot 1`] = `
-<styled.section>
+<Container>
   <PageSectionHeader
     description={
       <UNDEFINED>
-        <styled.span>
+        <styled__Description>
           We thrive by working, thinking, and growing like a technology driven organisation. This is our mission, and our promise. Here’s how we do it:
-        </styled.span>
+        </styled__Description>
         <Link
           activeClassName="___active"
           href="/case-studies"
@@ -19,6 +19,6 @@ exports[`compositions/homepage/HowWeDoIt snapshot 1`] = `
     title="How we do it"
   />
   <ProductList />
-  <Styled(styled.hr) />
-</styled.section>
+  <PageRule />
+</Container>
 `;

--- a/src/compositions/pages/Home/Industries/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/Industries/__snapshots__/spec.jsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`compositions/homepage/Industries snapshot 1`] = `
-<styled.section>
+<Container>
   <PageSectionHeader
     description="We’re proud to work with some amazing clients. No matter how big or small, their trust and collaboration allow us meticulous plan, craft and build their technology future."
     title="Industries"
   />
   <IndustryGrid />
-</styled.section>
+</Container>
 `;

--- a/src/compositions/pages/Home/ServicesAboutUs/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/ServicesAboutUs/__snapshots__/spec.jsx.snap
@@ -1,32 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`compositions/homepage/ServicesAboutUs snapshot 1`] = `
-<styled.section
+<Container
   wide={true}
 >
-  <styled.ul>
-    <styled.li>
-      <styled.div>
-        <styled.h5>
+  <TileGrid>
+    <styled__Tile>
+      <styled__TileContent>
+        <styled__TileContentTitle>
           Services
-        </styled.h5>
-        <styled.p>
+        </styled__TileContentTitle>
+        <styled__TileContentBody>
           We enable your organisation to deliver world-class technology and user experiences, long after we leave.
-        </styled.p>
-      </styled.div>
-    </styled.li>
-    <styled.li
+        </styled__TileContentBody>
+      </styled__TileContent>
+    </styled__Tile>
+    <styled__Tile
       colour="darker"
     >
-      <styled.div>
-        <styled.h5>
+      <styled__TileContent>
+        <styled__TileContentTitle>
           About Us
-        </styled.h5>
-        <styled.p>
+        </styled__TileContentTitle>
+        <styled__TileContentBody>
           We have team members from a broad spectrum of backgrounds and incredible technology companies.
-        </styled.p>
-      </styled.div>
-    </styled.li>
-  </styled.ul>
-</styled.section>
+        </styled__TileContentBody>
+      </styled__TileContent>
+    </styled__Tile>
+  </TileGrid>
+</Container>
 `;

--- a/src/compositions/pages/Home/WeEnable/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/WeEnable/__snapshots__/spec.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`compositions/homepage/WeEnable snapshot 1`] = `
-<styled.section>
+<Container>
   <PageSectionHeader
     description={null}
     title="We enable you to..."
@@ -26,6 +26,6 @@ exports[`compositions/homepage/WeEnable snapshot 1`] = `
       Grow a technology culture
     </Item>
   </CheckList>
-  <Styled(styled.hr) />
-</styled.section>
+  <PageRule />
+</Container>
 `;

--- a/src/compositions/pages/Home/WorkWithUs/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/WorkWithUs/__snapshots__/spec.jsx.snap
@@ -1,24 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`compositions/homepage/WorkWithUs snapshot 1`] = `
-<styled.section
+<Container
   wide={true}
 >
-  <styled.h4>
+  <styled__Title>
     Work with us
-  </styled.h4>
-  <styled.p>
-    <Styled(Link)
+  </styled__Title>
+  <styled__Details>
+    <styled__Link
       href="mailto:hello@yld.io"
     >
       hello@yld.io
-    </Styled(Link)>
+    </styled__Link>
      / 
-    <Styled(Link)
+    <styled__Link
       href="tel:+44-203-514-4678"
     >
       +44 (0) 203 514 4678
-    </Styled(Link)>
-  </styled.p>
-</styled.section>
+    </styled__Link>
+  </styled__Details>
+</Container>
 `;


### PR DESCRIPTION
Apparently it wasn't being applied in tests which was the main reason I added the plugin - this should fix that and allow us to select styled components easily.

I had to update all the snapshots!