### PR TITLE
Home & Services pages end-to-end coverage

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,15 @@
       "plugins": [["babel-plugin-styled-components", { "displayName": true }]]
     },
     "production": {
-      "plugins": [["babel-plugin-styled-components", { "displayName": false }]]
+      "plugins": [
+        ["babel-plugin-styled-components", { "displayName": false }],
+        [
+          "babel-plugin-remove-attribute",
+          {
+            "attribute": "data-selector"
+          }
+        ]
+      ]
     }
   },
   "plugins": [

--- a/circle.yml
+++ b/circle.yml
@@ -38,6 +38,8 @@ jobs:
           command: yarn ci:lint
   build:
     <<: *defaults
+    environment:
+      - BABEL_ENV: test
     steps:
       - checkout
       - restore_cache:

--- a/cypress/integration/homepage.js
+++ b/cypress/integration/homepage.js
@@ -1,14 +1,22 @@
 describe('features/homepage', () => {
-  it('visits the homepage', () => {
+  it('can land on the homepage', () => {
     cy.visit('/');
-
     cy.title().should('eq', 'YLD | Home');
   });
 
-  it.skip('allows navigation to page 2', () => {
+  it('shows a navigation menu', () => {
     cy.visit('/');
-    cy.contains('Go to page 2').click();
+    cy.getComponent('component:navigation');
+  });
 
-    cy.contains('Hi from the second page').should('be.visible');
+  it('shows relevant homepage sections', () => {
+    cy.visit('/');
+    cy.getComponent('home:build-better');
+    cy.getComponent('home:case-studies');
+    cy.getComponent('home:industries');
+    cy.getComponent('home:we-enable');
+    cy.getComponent('home:how-we-do-it');
+    cy.getComponent('home:community');
+    cy.getComponent('home:services-about-us');
   });
 });

--- a/cypress/integration/navigation.js
+++ b/cypress/integration/navigation.js
@@ -8,6 +8,7 @@ describe('features/navigation', () => {
 
   it('can navigate to /services', () => {
     cy.visit('/');
+    cy.awaitRender();
 
     cy
       .getComponent('component:navigation')

--- a/cypress/integration/navigation.js
+++ b/cypress/integration/navigation.js
@@ -1,0 +1,19 @@
+describe('features/navigation', () => {
+  it('can navigate home', () => {
+    cy.visit('/services');
+
+    cy.getComponent('component:logo').click();
+    cy.pathEq('/');
+  });
+
+  it('can navigate to /services', () => {
+    cy.visit('/');
+
+    cy
+      .getComponent('component:navigation')
+      .contains('Services')
+      .click();
+
+    cy.pathEq('/services');
+  });
+});

--- a/cypress/integration/services.js
+++ b/cypress/integration/services.js
@@ -1,0 +1,21 @@
+describe('features/services', () => {
+  it('can land on the services page', () => {
+    cy.visit('/services');
+    cy.title().should('eq', 'YLD | Services');
+  });
+
+  it('shows a navigation menu', () => {
+    cy.visit('/services');
+    cy.getComponent('component:navigation');
+  });
+
+  it('shows relevant homepage sections', () => {
+    cy.visit('/services');
+    cy.getComponent('services:hero');
+    cy.getComponent('services:table');
+    cy.getComponent('services:our-approach');
+    cy.getComponent('services:design-product');
+    cy.getComponent('services:engineering');
+    cy.getComponent('services:training');
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,7 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+Cypress.Commands.add('getComponent', selector => {
+  cy.get(`[data-selector="${selector}"]`);
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -27,3 +27,9 @@
 Cypress.Commands.add('getComponent', selector => {
   cy.get(`[data-selector="${selector}"]`);
 });
+
+Cypress.Commands.add('pathEq', path => {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.eq(path);
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -7,29 +7,56 @@
 // commands please read more here:
 // https://on.cypress.io/custom-commands
 // ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add("login", (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This is will overwrite an existing command --
-// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+/*
+  cy.getComponent(String selector)
+
+  Less brittle method of finding a component on the page by the selector we have
+  defined
+
+  Usage:
+
+  cy.getComponent('component:navigation');
+*/
 
 Cypress.Commands.add('getComponent', selector => {
   cy.get(`[data-selector="${selector}"]`);
 });
 
+/*
+  cy.pathEq(String path)
+
+  Assert that the current pathName equals $path
+
+  Usage:
+
+  cy.pathEq('/services');
+*/
+
 Cypress.Commands.add('pathEq', path => {
   cy.location().should(loc => {
     expect(loc.pathname).to.eq(path);
   });
+});
+
+/*
+  cy.awaitRender()
+
+  Sometimes when interacting with elements, Cypress will actually perform an interaction
+  before React has mounted, which will make the test fail as the dom element has changed between
+  visiting the page and interacting. Using this, we can wait until Gatsby has rendered
+  our application on the page.
+
+  See gatsby-browser.js for where this property is attached.
+
+  Usage:
+
+  cy.visit('/path');
+  cy.awaitRender();
+
+  (...interact with dom)
+*/
+
+Cypress.Commands.add('awaitRender', () => {
+  cy.window().should('have.property', 'GATSBY_RENDERED', true);
 });

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,4 +4,6 @@
  * See: https://www.gatsbyjs.org/docs/browser-apis/
  */
 
-// You can delete this file if you're not using it
+exports.onInitialClientRender = () => {
+  window.GATSBY_RENDERED = true;
+};

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "babel-plugin-module-resolver": "^3.1.1",
+    "babel-plugin-remove-attribute": "^0.0.8",
     "babel-plugin-styled-components": "^1.5.1",
     "cypress": "^2.1.0",
     "enzyme": "^3.3.0",

--- a/src/components/Logo/__snapshots__/spec.jsx.snap
+++ b/src/components/Logo/__snapshots__/spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`components/Logo snapshot 1`] = `
 <GatsbyLink
+  data-selector="component:logo"
   to="/"
 >
   <styled__LogoImage

--- a/src/components/Logo/index.jsx
+++ b/src/components/Logo/index.jsx
@@ -6,7 +6,7 @@ import { LogoImage } from './styled';
 
 export default function Logo() {
   return (
-    <Link to="/">
+    <Link data-selector="component:logo" to="/">
       <LogoImage src={logo} alt="YLD Logo" />
     </Link>
   );

--- a/src/components/Navigation/__snapshots__/spec.jsx.snap
+++ b/src/components/Navigation/__snapshots__/spec.jsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/Navigation snapshot 1`] = `
-<nav>
+<nav
+  data-selector="component:navigation"
+>
   <styled__List>
     <styled__Item>
       <styled__Link

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -3,7 +3,7 @@ import { Link, ButtonLink, List, Item } from './styled';
 
 export default function Navigation() {
   return (
-    <nav>
+    <nav data-selector="component:navigation">
       <List>
         <Item>
           <Link href="/case-studies">Case Studies</Link>

--- a/src/compositions/pages/Home/BuildBetter/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/BuildBetter/__snapshots__/spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`compositions/homepage/BuildBetter snapshot 1`] = `
 <PageSection
+  data-selector="home:build-better"
   gradient={false}
   gradientHeight="50%"
 >

--- a/src/compositions/pages/Home/BuildBetter/index.jsx
+++ b/src/compositions/pages/Home/BuildBetter/index.jsx
@@ -6,7 +6,7 @@ import PageHero from 'components/PageHero';
 import { Paragraph, Title } from './styled';
 
 const BuildBetter = () => (
-  <PageSection>
+  <PageSection data-selector="home:build-better">
     <PageHero title={<Title>Build better</Title>}>
       <Paragraph>
         Great companies go beyond their customers expectations, over and over

--- a/src/compositions/pages/Home/CaseStudies/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/CaseStudies/__snapshots__/spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`compositions/homepage/CaseStudies snapshot 1`] = `
 <PageSection
+  data-selector="home:case-studies"
   gradient={false}
   gradientHeight="50%"
   wide={true}

--- a/src/compositions/pages/Home/CaseStudies/index.jsx
+++ b/src/compositions/pages/Home/CaseStudies/index.jsx
@@ -13,7 +13,7 @@ import {
 } from './styled';
 
 const CaseStudies = () => (
-  <PageSection wide>
+  <PageSection wide data-selector="home:case-studies">
     <TileGrid>
       <Tile>
         <TileContent>

--- a/src/compositions/pages/Home/Community/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/Community/__snapshots__/spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`compositions/Home/Community snapshot 1`] = `
 <PageSection
+  data-selector="home:community"
   gradient={false}
   gradientHeight="50%"
 >

--- a/src/compositions/pages/Home/Community/index.jsx
+++ b/src/compositions/pages/Home/Community/index.jsx
@@ -7,7 +7,7 @@ import UpcomingEvents from './UpcomingEvents';
 import { Rule } from './styled';
 
 const Community = () => (
-  <PageSection>
+  <PageSection data-selector="home:community">
     <PageSectionHeader
       title="Community"
       description="We define ourselves by the people who represent us. Our emphasis on community and culture creates an environment where we prioritise supporting and nurturing people’s development."

--- a/src/compositions/pages/Home/HowWeDoIt/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/HowWeDoIt/__snapshots__/spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`compositions/homepage/HowWeDoIt snapshot 1`] = `
 <PageSection
+  data-selector="home:how-we-do-it"
   gradient={true}
   gradientHeight="50%"
 >

--- a/src/compositions/pages/Home/HowWeDoIt/index.jsx
+++ b/src/compositions/pages/Home/HowWeDoIt/index.jsx
@@ -18,7 +18,7 @@ const HeaderDescription = (
 );
 
 const HowWeDoIt = () => (
-  <PageSection gradient>
+  <PageSection data-selector="home:how-we-do-it" gradient>
     <PageSectionHeader description={HeaderDescription} title="How we do it" />
     <ProductList />
   </PageSection>

--- a/src/compositions/pages/Home/Industries/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/Industries/__snapshots__/spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`compositions/homepage/Industries snapshot 1`] = `
 <PageSection
+  data-selector="home:industries"
   gradient={true}
   gradientHeight="50%"
 >

--- a/src/compositions/pages/Home/Industries/index.jsx
+++ b/src/compositions/pages/Home/Industries/index.jsx
@@ -6,7 +6,7 @@ import PageSectionHeader from 'components/PageSectionHeader';
 import IndustryGrid from './IndustryGrid';
 
 const Industries = () => (
-  <PageSection gradient>
+  <PageSection data-selector="home:industries" gradient>
     <PageSectionHeader
       description="We’re proud to work with some amazing clients. No matter how big or small, their trust and collaboration allow us meticulous plan, craft and build their technology future."
       title="Industries"

--- a/src/compositions/pages/Home/ServicesAboutUs/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/ServicesAboutUs/__snapshots__/spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`compositions/homepage/ServicesAboutUs snapshot 1`] = `
 <Container
+  data-selector="home:services-about-us"
   wide={true}
 >
   <TileGrid>

--- a/src/compositions/pages/Home/ServicesAboutUs/index.jsx
+++ b/src/compositions/pages/Home/ServicesAboutUs/index.jsx
@@ -9,7 +9,7 @@ import {
 } from './styled';
 
 const ServicesAboutUs = () => (
-  <Section wide>
+  <Section wide data-selector="home:services-about-us">
     <TileGrid>
       <Tile>
         <TileContent>

--- a/src/compositions/pages/Home/WeEnable/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Home/WeEnable/__snapshots__/spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`compositions/homepage/WeEnable snapshot 1`] = `
 <PageSection
+  data-selector="home:we-enable"
   gradient={false}
   gradientHeight="50%"
 >

--- a/src/compositions/pages/Home/WeEnable/index.jsx
+++ b/src/compositions/pages/Home/WeEnable/index.jsx
@@ -6,7 +6,7 @@ import PageSectionHeader from 'components/PageSectionHeader';
 import PageRule from 'components/PageRule';
 
 const WeEnable = () => (
-  <PageSection>
+  <PageSection data-selector="home:we-enable">
     <PageSectionHeader title="We enable you to..." />
     <CheckList>
       <Item>Build custom software solutions that become an asset</Item>

--- a/src/compositions/pages/Services/ServiceList/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Services/ServiceList/__snapshots__/spec.jsx.snap
@@ -3,6 +3,7 @@
 exports[`compositions/pages/Services/ServiceList snapshot 1`] = `
 <React.Fragment>
   <PageSection
+    data-selector="services:our-approach"
     gradient={false}
     gradientHeight="50%"
     id="approach"
@@ -36,6 +37,7 @@ exports[`compositions/pages/Services/ServiceList snapshot 1`] = `
     </Subservice>
   </PageSection>
   <PageSection
+    data-selector="services:design-product"
     gradient={true}
     gradientHeight="100%"
     id="design"
@@ -106,6 +108,7 @@ exports[`compositions/pages/Services/ServiceList snapshot 1`] = `
     </Subservice>
   </PageSection>
   <PageSection
+    data-selector="services:engineering"
     gradient={false}
     gradientHeight="50%"
     id="engineering"
@@ -139,6 +142,7 @@ exports[`compositions/pages/Services/ServiceList snapshot 1`] = `
     </Subservice>
   </PageSection>
   <PageSection
+    data-selector="services:training"
     gradient={true}
     gradientHeight="100%"
     id="training"

--- a/src/compositions/pages/Services/ServiceList/index.jsx
+++ b/src/compositions/pages/Services/ServiceList/index.jsx
@@ -7,7 +7,7 @@ import Subservice from './Subservice';
 
 const ServiceList = () => (
   <Fragment>
-    <PageSection id="approach">
+    <PageSection id="approach" data-selector="services:our-approach">
       <Title>Our Approach</Title>
       <Support>
         We help you future proof your business though a new style of consulting,
@@ -48,7 +48,12 @@ const ServiceList = () => (
         excellence, fast.
       </Subservice>
     </PageSection>
-    <PageSection gradient gradientHeight="100%" id="design">
+    <PageSection
+      gradient
+      gradientHeight="100%"
+      id="design"
+      data-selector="services:design-product"
+    >
       <Title>Design &amp; Product</Title>
       <Support>
         A great company continuously finds better solutions to its customers
@@ -118,7 +123,7 @@ const ServiceList = () => (
         </Link>
       </Subservice>
     </PageSection>
-    <PageSection id="engineering">
+    <PageSection id="engineering" data-selector="services:engineering">
       <Title>Engineering</Title>
       <Support>
         We help you future proof your business though a new style of consulting,
@@ -159,7 +164,12 @@ const ServiceList = () => (
         excellence, fast.
       </Subservice>
     </PageSection>
-    <PageSection gradient gradientHeight="100%" id="training">
+    <PageSection
+      gradient
+      gradientHeight="100%"
+      id="training"
+      data-selector="services:training"
+    >
       <Title>Training</Title>
       <Support>
         A great company continuously finds better solutions to its customers

--- a/src/compositions/pages/Services/__snapshots__/spec.jsx.snap
+++ b/src/compositions/pages/Services/__snapshots__/spec.jsx.snap
@@ -3,6 +3,7 @@
 exports[`compositions/pages/Services snapshot 1`] = `
 <React.Fragment>
   <PageSection
+    data-selector="services:hero"
     gradient={false}
     gradientHeight="50%"
   >
@@ -14,6 +15,7 @@ exports[`compositions/pages/Services snapshot 1`] = `
     </PageHero>
   </PageSection>
   <PageSection
+    data-selector="services:table"
     gradient={true}
     gradientHeight="50%"
   >

--- a/src/compositions/pages/Services/index.jsx
+++ b/src/compositions/pages/Services/index.jsx
@@ -10,7 +10,7 @@ import Tiles from './Tiles';
 
 const ServicesPage = () => (
   <Fragment>
-    <PageSection>
+    <PageSection data-selector="services:hero">
       <PageHero
         before="services"
         title="Great companies go beyond their customers expectations, over and over again."
@@ -19,7 +19,7 @@ const ServicesPage = () => (
         experiences, long after we leave.
       </PageHero>
     </PageSection>
-    <PageSection gradient>
+    <PageSection gradient data-selector="services:table">
       <ProductList />
     </PageSection>
     <ServiceList />

--- a/yarn.lock
+++ b/yarn.lock
@@ -809,6 +809,10 @@ babel-plugin-module-resolver@^3.1.1:
     reselect "^3.0.1"
     resolve "^1.4.0"
 
+babel-plugin-remove-attribute@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-remove-attribute/-/babel-plugin-remove-attribute-0.0.8.tgz#239db11af2917221a935b32559262191e4b09866"
+
 babel-plugin-styled-components@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.5.1.tgz#31dbeb696d1354d1585e60d66c7905f5e474afcd"


### PR DESCRIPTION
Added some golden-path feature tests which cover some basic functionality on the site.
The premise of these is to tell us quickly if something crucial breaks.

I added `babel-plugin-remove-attribute` to remove the `data-selector` attribs I've planted in production. These `data-selector`s provide a good target for our test runner to target on the page, as they will only change if we explicitly change them, unlike HTML element or class based selectors.

I've also added a `cy.awaitRender()` command which will wait for React to be mounted on the page. This should be used on tests that are failing when Cypress tries to interact with an element and thinks it is not visible due to the mounting.

- [x] Code review