### PR TITLE
fixed overflowing button by changing the font to 100%

### DIFF
--- a/src/components/button.js
+++ b/src/components/button.js
@@ -18,7 +18,7 @@ export default styled(Link)`
 
   text-decoration: none;
   line-height: ${remcalc(25)};
-  font-size: ${remcalc(18)};
+  font-size: 100%;
   font-weight: 400;
 
   ${is('white')`


### PR DESCRIPTION
## Description

fix to issue #66 : button overflows its box. Whilst this is not a perfect fix (ideally this would be @media queries), this fixes the immediate problem. 

## Motivation & Context

<!-- Link to Trello tile, Github issue etc -->

## Screenshots

<!-- Add any screenshots showing your changes -->

## Types of Changes

<!-- Check all that apply -->

- [ ] New feature
- [x] Bug fix
- [ ] Tech debt

## Check List

<!-- check all that apply (where appropriate) -->

- [ ] Unit tests added
- [ ] E2E tests added
- [ ] All tests pass
- [ ] Documentation updated
- [ ] Code has been formatted and linted
