### PR TITLE
Changing default fonts

### DIFF
--- a/src/components/base.js
+++ b/src/components/base.js
@@ -11,7 +11,7 @@ export default class extends PureComponent {
 
       body, html {
         font-size: 16px;
-        font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica, sans-serif;
+        font-family: "Roboto", Helvetica, sans-serif;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
         line-height: 1.5;


### PR DESCRIPTION
## Description

On safari the current page loads with a Flickr. It shows that when the Roboto font is not available it loads a font quite different from Roboto. 

This change sets a smaller list of fonts, which "fixes it in my computer". I'm obviously not a front end dev so this is probably pretty bad but just trying to help :)
